### PR TITLE
[create-doks-with-terraform-flux] Remove redundant 'github.com' string from the `github_ssh_pub_key` variable

### DIFF
--- a/create-doks-with-terraform-flux/variables.tf
+++ b/create-doks-with-terraform-flux/variables.tf
@@ -47,7 +47,7 @@ variable "github_token" {
 variable "github_ssh_pub_key" {
   description = "GitHub SSH public key"
   type        = string
-  default     = "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="
+  default     = "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="
 }
 
 variable "git_repository_name" {


### PR DESCRIPTION
Fixes #18.