### PR TITLE
[DOKS-Egress-Gateway] Include details of setting default VPC

### DIFF
--- a/DOKS-Egress-Gateway/README.md
+++ b/DOKS-Egress-Gateway/README.md
@@ -434,8 +434,6 @@ Next, you will take the final step and provision the egress gateway droplet for 
 
 **The egress gateway Droplet and DOKS cluster must be in the same VPC (or on the same network) for the whole setup to work !!!**
 
-Once the DigitalOcean Crossplane provider supports specifying the VPC our Droplet is deployed to we can include this in our manifest. Until this time you must [set your default VPC](https://docs.digitalocean.com/products/networking/vpc/how-to/set-default-vpc/), this will ensure the Egress Gateway Droplet is deployed to the same VPC as your Kubernetes worker nodes.
-
 Now that the DigitalOcean provider is installed and properly configured, you can proceed and create the actual Droplet resource to act as an egress gateway for the demo used this blueprint.
 
 The Crossplane Droplet CRD used in this blueprint looks like below:
@@ -450,6 +448,7 @@ spec:
     region: nyc1
     size: s-1vcpu-1gb
     image: ubuntu-20-04-x64
+    vpcUuid: 4b5e125e-c52e-4578-93a7-01341ee927ac
     sshKeys:
       - "7e:9c:b7:ee:74:16:a5:f7:62:12:b1:72:dc:51:71:85"
     userData: |
@@ -498,9 +497,10 @@ To create the egress gateway Droplet via Kubernetes, please follow below steps:
     code egress-gw-droplet.yaml
     ```
 
-    **Hint:**
+    **Hints:**
 
-    If you have specific SSH keys you want to add at Droplet creation time, you can do so by uncommenting the `sshKeys` field from the spec. Then, replace the `<>` placeholders with your SSH key fingerprint. To list the available SSH keys associated with your account and their fingerprint, you can do so by issuing the following command - `doctl compute ssh-key list`.
+    * If you have specific SSH keys you want to add at Droplet creation time, you can do so by uncommenting the `sshKeys` field from the spec. Then, replace the `<>` placeholders with your SSH key fingerprint. To list the available SSH keys associated with your account and their fingerprint, you can do so by issuing the following command - `doctl compute ssh-key list`.
+    * The egress gateway Droplet and DOKS cluster must be in the same VPC. Use the following command to get your VPC ID - `doctl vpcs list` and set this by uncommenting the `vpcUuid` field from the spec.
 
 3. Save and apply the manifest using `kubectl`:
 

--- a/DOKS-Egress-Gateway/README.md
+++ b/DOKS-Egress-Gateway/README.md
@@ -434,6 +434,8 @@ Next, you will take the final step and provision the egress gateway droplet for 
 
 **The egress gateway Droplet and DOKS cluster must be in the same VPC (or on the same network) for the whole setup to work !!!**
 
+Once the DigitalOcean Crossplane provider supports specifying the VPC our Droplet is deployed to we can include this in our manifest. Until this time you must [set your default VPC](https://docs.digitalocean.com/products/networking/vpc/how-to/set-default-vpc/), this will ensure the Egress Gateway Droplet is deployed to the same VPC as your Kubernetes worker nodes.
+
 Now that the DigitalOcean provider is installed and properly configured, you can proceed and create the actual Droplet resource to act as an egress gateway for the demo used this blueprint.
 
 The Crossplane Droplet CRD used in this blueprint looks like below:

--- a/DOKS-Egress-Gateway/assets/manifests/crossplane/egress-gw-droplet.yaml
+++ b/DOKS-Egress-Gateway/assets/manifests/crossplane/egress-gw-droplet.yaml
@@ -8,6 +8,7 @@ spec:
     region: nyc1
     size: s-1vcpu-1gb
     image: ubuntu-20-04-x64
+    # vpcUuid: "<YOUR_VPC_ID_HERE>"
     # sshKeys:
     #   - "<YOUR_PUBLIC_SSH_KEY_FINGERPRINT_HERE>"
     userData: |


### PR DESCRIPTION
I couldn't see that [crossplane-contrib/provider-digitalocean](https://github.com/crossplane-contrib/provider-digitalocean) supports 'vpc_uuid' so I have added instructions on setting the default VPC for now. I have opened an [issue](https://github.com/crossplane-contrib/provider-digitalocean/issues/72) for this. I hope this helps.