### PR TITLE
Update README.md

### DIFF
--- a/DOKS-Egress-Gateway/README.md
+++ b/DOKS-Egress-Gateway/README.md
@@ -187,7 +187,6 @@ The output looks similar to:
 NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
 crossplane                 1/1     1            1           3d19h
 crossplane-rbac-manager    1/1     1            1           3d19h
-provider-do-cad6fc11e8d5   1/1     1            1           3d19h
 ```
 
 All pods must be up and running (check the `READY` column). In the next step, a short introduction is given about the static routes operator used in this guide.


### PR DESCRIPTION
removed digital ocean provider deployment from the list of deployments right after installing crossplane, since it is installed later on and it will absent at that stage of the installation.